### PR TITLE
add TLS setting in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,13 @@ grafana-cli plugins install grafana-kubernetes-app
      ...
      -----END CERTIFICATE-----
      ```
+   All TLS certs/keys are from .kube/config, need `base64 -d` to decode:
+
+   | field | comment |
+   | ------ | ------ |
+   | CA Cert | clusters.cluster.certificate-authority-data |
+   | Client Cert | users.user.client-certificate-data |
+   | Client Key | users.user.client-key-data |
 
 4. Choose the Prometheus datasource that will be used for reading data in the dashboards.
 


### PR DESCRIPTION
There is not details about fill out which val into TLS setting field.

According to "How to configure cluster #35", add related info.

Signed-off-by: Xiang Dai <xiang.dai@iluvatar.ai>