### PR TITLE
Fix typo

### DIFF
--- a/dist/components/clusters/partials/clusters.html
+++ b/dist/components/clusters/partials/clusters.html
@@ -14,7 +14,7 @@
 	<div ng-if="ctrl.clusters.length === 0">
 		<div style="text-align: center; padding-top: 90px; min-height: 220px; min-width: 400px;  margin: 0 auto;">
 			<i ng-class="icon" class="icon-gf icon-gf-endpoint no-endpoints"></i>
-			<p ng-if="ctrl.isOrgEditor">Looks like you don’t have any clulsters yet.<br>
+			<p ng-if="ctrl.isOrgEditor">Looks like you don’t have any clusters yet.<br>
 				<a class="highlight-word" href="plugins/grafana-kubernetes-app/page/cluster-config">Add a new cluster</a>
 			</p>
 			<p ng-if="!ctrl.isOrgEditor">Your org does not have any clusters configured. Contact your org admin.

--- a/src/components/clusters/partials/clusters.html
+++ b/src/components/clusters/partials/clusters.html
@@ -14,7 +14,7 @@
 	<div ng-if="ctrl.clusters.length === 0">
 		<div style="text-align: center; padding-top: 90px; min-height: 220px; min-width: 400px;  margin: 0 auto;">
 			<i ng-class="icon" class="icon-gf icon-gf-endpoint no-endpoints"></i>
-			<p ng-if="ctrl.isOrgEditor">Looks like you don’t have any clulsters yet.<br>
+			<p ng-if="ctrl.isOrgEditor">Looks like you don’t have any clusters yet.<br>
 				<a class="highlight-word" href="plugins/grafana-kubernetes-app/page/cluster-config">Add a new cluster</a>
 			</p>
 			<p ng-if="!ctrl.isOrgEditor">Your org does not have any clusters configured. Contact your org admin.


### PR DESCRIPTION
Hi.

I came across a typo when using this plugin. 
The word cluster has been written wrong as clulster in two files.

This PR corrects said typo