### PR TITLE
Update exporters keys and metrics names, Kubernetes API Versions and Fix dashboards

### DIFF
--- a/dist/components/clusters/clusterConfig.js
+++ b/dist/components/clusters/clusterConfig.js
@@ -14,10 +14,10 @@ System.register(['lodash', 'app/core/app_events', 'angular'], function(exports_1
                 angular_1 = angular_1_1;
             }],
         execute: function() {
-            nodeExporterImage = 'quay.io/prometheus/node-exporter:v0.15.0';
-            kubestateImage = 'quay.io/coreos/kube-state-metrics:v1.1.0';
+            nodeExporterImage = 'quay.io/prometheus/node-exporter:v0.18.1';
+            kubestateImage = 'quay.io/coreos/kube-state-metrics:v1.8.0';
             kubestateDeployment = {
-                "apiVersion": "apps/v1beta1",
+                "apiVersion": "apps/v1",
                 "kind": "Deployment",
                 "metadata": {
                     "name": "kube-state-metrics",
@@ -61,7 +61,7 @@ System.register(['lodash', 'app/core/app_events', 'angular'], function(exports_1
             };
             nodeExporterDaemonSet = {
                 "kind": "DaemonSet",
-                "apiVersion": "extensions/v1beta1",
+                "apiVersion": "apps/v1",
                 "metadata": {
                     "name": "node-exporter",
                     "namespace": "kube-system"

--- a/dist/components/clusters/clusterConfig.js
+++ b/dist/components/clusters/clusterConfig.js
@@ -199,7 +199,7 @@ System.register(['lodash', 'app/core/app_events', 'angular'], function(exports_1
                 ClusterConfigCtrl.prototype.getDeployments = function () {
                     var self = this;
                     return this.backendSrv.request({
-                        url: 'api/datasources/proxy/' + self.cluster.id + '/apis/apps/v1beta1/namespaces/kube-system/deployments',
+                        url: 'api/datasources/proxy/' + self.cluster.id + '/apis/apps/v1/namespaces/kube-system/deployments',
                         method: 'GET',
                         headers: {
                             'Content-Type': 'application/json'
@@ -295,14 +295,14 @@ System.register(['lodash', 'app/core/app_events', 'angular'], function(exports_1
                 };
                 ClusterConfigCtrl.prototype.checkApiVersion = function (clusterId) {
                     return this.backendSrv.request({
-                        url: 'api/datasources/proxy/' + clusterId + '/apis/extensions/v1beta1',
+                        url: 'api/datasources/proxy/' + clusterId + '/apis/apps/v1',
                         method: 'GET',
                         headers: {
                             'Content-Type': 'application/json'
                         }
                     }).then(function (result) {
                         if (!result.resources || result.resources.length === 0) {
-                            throw "This Kubernetes cluster does not support v1beta1 of the API which is needed to deploy automatically. " +
+                            throw "This Kubernetes cluster does not support v1 of the API which is needed to deploy automatically. " +
                                 "You can install manually using the instructions at the bottom of the page.";
                         }
                     });
@@ -319,7 +319,7 @@ System.register(['lodash', 'app/core/app_events', 'angular'], function(exports_1
                 };
                 ClusterConfigCtrl.prototype.createDaemonSet = function (clusterId, daemonSet) {
                     return this.backendSrv.request({
-                        url: 'api/datasources/proxy/' + clusterId + '/apis/extensions/v1beta1/namespaces/kube-system/daemonsets',
+                        url: 'api/datasources/proxy/' + clusterId + '/apis/apps/v1/namespaces/kube-system/daemonsets',
                         method: 'POST',
                         data: daemonSet,
                         headers: {
@@ -329,13 +329,13 @@ System.register(['lodash', 'app/core/app_events', 'angular'], function(exports_1
                 };
                 ClusterConfigCtrl.prototype.deleteDaemonSet = function (clusterId) {
                     return this.backendSrv.request({
-                        url: 'api/datasources/proxy/' + clusterId + '/apis/extensions/v1beta1/namespaces/kube-system/daemonsets/node-exporter',
+                        url: 'api/datasources/proxy/' + clusterId + '/apis/apps/v1/namespaces/kube-system/daemonsets/node-exporter',
                         method: 'DELETE',
                     });
                 };
                 ClusterConfigCtrl.prototype.createDeployment = function (clusterId, deployment) {
                     return this.backendSrv.request({
-                        url: 'api/datasources/proxy/' + clusterId + '/apis/apps/v1beta1/namespaces/kube-system/deployments',
+                        url: 'api/datasources/proxy/' + clusterId + '/apis/apps/v1/namespaces/kube-system/deployments',
                         method: 'POST',
                         data: deployment,
                         headers: {
@@ -346,12 +346,12 @@ System.register(['lodash', 'app/core/app_events', 'angular'], function(exports_1
                 ClusterConfigCtrl.prototype.deleteDeployment = function (clusterId, deploymentName) {
                     var _this = this;
                     return this.backendSrv.request({
-                        url: 'api/datasources/proxy/' + clusterId + '/apis/apps/v1beta1/namespaces/kube-system/deployments/' + deploymentName,
+                        url: 'api/datasources/proxy/' + clusterId + '/apis/apps/v1/namespaces/kube-system/deployments/' + deploymentName,
                         method: 'DELETE'
                     }).then(function () {
                         return _this.backendSrv.request({
                             url: 'api/datasources/proxy/' + clusterId +
-                                '/apis/extensions/v1beta1/namespaces/kube-system/replicasets?labelSelector=grafanak8sapp%3Dtrue',
+                                '/apis/apps/v1/namespaces/kube-system/replicasets?labelSelector=grafanak8sapp%3Dtrue',
                             method: 'DELETE'
                         });
                     });

--- a/dist/components/clusters/clusterConfig.ts
+++ b/dist/components/clusters/clusterConfig.ts
@@ -205,7 +205,7 @@ export class ClusterConfigCtrl {
   getDeployments() {
     var self = this;
     return this.backendSrv.request({
-      url: 'api/datasources/proxy/' + self.cluster.id + '/apis/apps/v1beta1/namespaces/kube-system/deployments',
+      url: 'api/datasources/proxy/' + self.cluster.id + '/apis/apps/v1/namespaces/kube-system/deployments',
       method: 'GET',
       headers: {
         'Content-Type': 'application/json'
@@ -308,14 +308,14 @@ export class ClusterConfigCtrl {
 
   checkApiVersion(clusterId) {
     return this.backendSrv.request({
-      url: 'api/datasources/proxy/' + clusterId + '/apis/extensions/v1beta1',
+      url: 'api/datasources/proxy/' + clusterId + '/apis/apps/v1',
       method: 'GET',
       headers: {
         'Content-Type': 'application/json'
       }
     }).then(result => {
       if (!result.resources || result.resources.length === 0) {
-        throw "This Kubernetes cluster does not support v1beta1 of the API which is needed to deploy automatically. " +
+        throw "This Kubernetes cluster does not support v1 of the API which is needed to deploy automatically. " +
           "You can install manually using the instructions at the bottom of the page.";
       }
     });
@@ -334,7 +334,7 @@ export class ClusterConfigCtrl {
 
   createDaemonSet(clusterId, daemonSet) {
     return this.backendSrv.request({
-      url: 'api/datasources/proxy/' + clusterId + '/apis/extensions/v1beta1/namespaces/kube-system/daemonsets',
+      url: 'api/datasources/proxy/' + clusterId + '/apis/apps/v1/namespaces/kube-system/daemonsets',
       method: 'POST',
       data: daemonSet,
       headers: {
@@ -345,14 +345,14 @@ export class ClusterConfigCtrl {
 
   deleteDaemonSet(clusterId) {
     return this.backendSrv.request({
-      url: 'api/datasources/proxy/' + clusterId + '/apis/extensions/v1beta1/namespaces/kube-system/daemonsets/node-exporter',
+      url: 'api/datasources/proxy/' + clusterId + '/apis/apps/v1/namespaces/kube-system/daemonsets/node-exporter',
       method: 'DELETE',
     });
   }
 
   createDeployment(clusterId, deployment) {
     return this.backendSrv.request({
-      url: 'api/datasources/proxy/' + clusterId + '/apis/apps/v1beta1/namespaces/kube-system/deployments',
+      url: 'api/datasources/proxy/' + clusterId + '/apis/apps/v1/namespaces/kube-system/deployments',
       method: 'POST',
       data: deployment,
       headers: {
@@ -363,12 +363,12 @@ export class ClusterConfigCtrl {
 
   deleteDeployment(clusterId, deploymentName) {
     return this.backendSrv.request({
-      url: 'api/datasources/proxy/' + clusterId + '/apis/apps/v1beta1/namespaces/kube-system/deployments/' + deploymentName,
+      url: 'api/datasources/proxy/' + clusterId + '/apis/apps/v1/namespaces/kube-system/deployments/' + deploymentName,
       method: 'DELETE'
     }).then(() => {
       return this.backendSrv.request({
         url: 'api/datasources/proxy/' + clusterId +
-          '/apis/extensions/v1beta1/namespaces/kube-system/replicasets?labelSelector=grafanak8sapp%3Dtrue',
+          '/apis/apps/v1/namespaces/kube-system/replicasets?labelSelector=grafanak8sapp%3Dtrue',
         method: 'DELETE'
       });
     });

--- a/dist/components/clusters/partials/clusters.html
+++ b/dist/components/clusters/partials/clusters.html
@@ -14,7 +14,7 @@
 	<div ng-if="ctrl.clusters.length === 0">
 		<div style="text-align: center; padding-top: 90px; min-height: 220px; min-width: 400px;  margin: 0 auto;">
 			<i ng-class="icon" class="icon-gf icon-gf-endpoint no-endpoints"></i>
-			<p ng-if="ctrl.isOrgEditor">Looks like you don’t have any clulsters yet.<br>
+			<p ng-if="ctrl.isOrgEditor">Looks like you don’t have any clusters yet.<br>
 				<a class="highlight-word" href="plugins/grafana-kubernetes-app/page/cluster-config">Add a new cluster</a>
 			</p>
 			<p ng-if="!ctrl.isOrgEditor">Your org does not have any clusters configured. Contact your org admin.

--- a/dist/dashboards/k8s-cluster.json
+++ b/dist/dashboards/k8s-cluster.json
@@ -5,7 +5,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "5.0.0-pre1"
+      "version": "5.0.4"
     },
     {
       "type": "datasource",
@@ -354,7 +354,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "(sum (node_filesystem_size{nodename=~\"$node\"}) - sum (node_filesystem_free{nodename=~\"$node\"})) / sum (node_filesystem_size{nodename=~\"$node\"})",
+          "expr": "(sum (node_filesystem_size_bytes{instance=~\"$node\"}) - sum (node_filesystem_free_bytes{instance=~\"$node\"})) / sum (node_filesystem_size_bytes{instance=~\"$node\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -693,14 +693,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(node_filesystem_size{nodename=~\"$node\"}) - sum(node_filesystem_free{nodename=~\"$node\"})",
+          "expr": "sum(node_filesystem_size_bytes{instance=~\"$node\"}) - sum(node_filesystem_free_bytes{instance=~\"$node\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "usage",
           "refId": "A"
         },
         {
-          "expr": "sum(node_filesystem_size{nodename=~\"$node\"})",
+          "expr": "sum(node_filesystem_size_bytes{instance=~\"$node\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "limit",

--- a/dist/dashboards/k8s-cluster.json
+++ b/dist/dashboards/k8s-cluster.json
@@ -8,19 +8,31 @@
       "version": "5.0.4"
     },
     {
-      "type": "datasource",
-      "id": "prometheus",
-      "name": "Prometheus",
-      "version": "1.0.0"
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": "5.0.0"
     },
     {
       "type": "panel",
       "id": "singlestat",
       "name": "Singlestat",
-      "version": ""
+      "version": "5.0.0"
     }
   ],
-  "annotations": {},
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
   "description": "Summary metrics about containers running on Kubernetes nodes.",
   "editable": true,
   "gnetId": null,
@@ -65,7 +77,7 @@
       "datasource": "$datasource",
       "format": "percentunit",
       "gauge": {
-        "maxValue": 1,
+        "maxValue": 100,
         "minValue": 0,
         "show": true,
         "thresholdLabels": false,
@@ -120,7 +132,7 @@
           "refId": "A"
         }
       ],
-      "thresholds": ".8,.9",
+      "thresholds": "80,90",
       "title": "Cluster Pod Usage",
       "type": "singlestat",
       "valueFontSize": "80%",
@@ -145,7 +157,7 @@
       "datasource": "$datasource",
       "format": "percentunit",
       "gauge": {
-        "maxValue": 1,
+        "maxValue": 100,
         "minValue": 0,
         "show": true,
         "thresholdLabels": false,
@@ -200,7 +212,7 @@
           "refId": "A"
         }
       ],
-      "thresholds": ".8,.9",
+      "thresholds": "80,90",
       "title": "Cluster CPU Usage",
       "type": "singlestat",
       "valueFontSize": "80%",
@@ -225,7 +237,7 @@
       "datasource": "$datasource",
       "format": "percentunit",
       "gauge": {
-        "maxValue": 1,
+        "maxValue": 100,
         "minValue": 0,
         "show": true,
         "thresholdLabels": false,
@@ -280,7 +292,7 @@
           "refId": "A"
         }
       ],
-      "thresholds": ".8,.9",
+      "thresholds": "80,90",
       "title": "Cluster Memory Usage",
       "type": "singlestat",
       "valueFontSize": "80%",
@@ -305,7 +317,7 @@
       "datasource": "$datasource",
       "format": "percentunit",
       "gauge": {
-        "maxValue": 1,
+        "maxValue": 100,
         "minValue": 0,
         "show": true,
         "thresholdLabels": false,
@@ -360,7 +372,7 @@
           "refId": "A"
         }
       ],
-      "thresholds": ".8,.9",
+      "thresholds": "80,90",
       "title": "Cluster Disk Usage",
       "type": "singlestat",
       "valueFontSize": "80%",
@@ -2065,7 +2077,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(delta(kube_pod_container_status_restarts{namespace=\"kube-system\"}[30m]))",
+          "expr": "sum(delta(kube_pod_container_status_restarts_total{namespace=~\"$namespace\"}[30m]))",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"

--- a/dist/dashboards/k8s-container.json
+++ b/dist/dashboards/k8s-container.json
@@ -5,7 +5,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "5.0.0-pre1"
+      "version": "5.0.4"
     },
     {
       "type": "panel",
@@ -126,10 +126,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(container_memory_usage_bytes{pod_name=~\"$pod\"}) by (pod_name)",
+          "expr": "sum(container_memory_usage_bytes{pod=~\"$pod\"}) by (pod)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{ pod_name }}",
+          "legendFormat": "{{ pod }}",
           "refId": "A"
         }
       ],
@@ -217,10 +217,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(container_cpu_usage_seconds_total{pod_name=~\"$pod\"}[2m])) by (pod_name)",
+          "expr": "sum(irate(container_cpu_usage_seconds_total{pod=~\"$pod\"}[2m])) by (pod)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{ pod_name }}",
+          "legendFormat": "{{ pod }}",
           "refId": "A"
         }
       ],
@@ -307,11 +307,11 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(container_network_transmit_bytes_total{pod_name=~\"$pod\", kubernetes_io_hostname=~\"$node\"}[2m])",
+          "expr": "rate(container_network_transmit_bytes_total{pod=~\"$pod\", kubernetes_io_hostname=~\"$node\"}[2m])",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "{{ pod_name }}",
+          "legendFormat": "{{ pod }}",
           "refId": "A"
         }
       ],
@@ -398,10 +398,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(container_network_receive_bytes_total{pod_name=~\"$pod\", kubernetes_io_hostname=~\"$node\"}[2m])",
+          "expr": "rate(container_network_receive_bytes_total{pod=~\"$pod\", kubernetes_io_hostname=~\"$node\"}[2m])",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{ pod_name }}",
+          "legendFormat": "{{ pod }}",
           "refId": "A"
         }
       ],
@@ -489,10 +489,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(container_fs_io_time_seconds_total{pod_name=~\"$pod\"}[2m])",
+          "expr": "rate(container_fs_io_time_seconds_total{pod=~\"$pod\"}[2m])",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{pod_name}}",
+          "legendFormat": "{{ pod }}",
           "refId": "A"
         }
       ],
@@ -577,10 +577,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(container_fs_write_seconds_total{pod_name=~\"$pod\"}[2m])",
+          "expr": "rate(container_fs_write_seconds_total{pod=~\"$pod\"}[2m])",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{ pod_name }}",
+          "legendFormat": "{{ pod }}",
           "refId": "A"
         }
       ],

--- a/dist/dashboards/k8s-deployments.json
+++ b/dist/dashboards/k8s-deployments.json
@@ -5,7 +5,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "5.0.0-pre1"
+      "version": "5.0.4"
     },
     {
       "type": "panel",

--- a/dist/dashboards/k8s-node.json
+++ b/dist/dashboards/k8s-node.json
@@ -5,7 +5,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "5.0.0-pre1"
+      "version": "5.0.4"
     },
     {
       "type": "panel",
@@ -437,7 +437,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(node_filesystem_free{nodename=~\"$node\"}) by (nodename)",
+          "expr": "sum(node_filesystem_free_bytes{instance=~\"$node\"}) by (nodename)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{ nodename }} free",

--- a/dist/dashboards/k8s-node.json
+++ b/dist/dashboards/k8s-node.json
@@ -143,7 +143,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum((avg(irate(node_cpu{nodename=~\"$node\", mode=\"system\"}[5m])) * 100))",
+          "expr": "sum((avg(irate(node_cpu_seconds_total{instance=~\"$node\", mode=\"system\"}[5m])) * 100))",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -152,21 +152,21 @@
           "refId": "A"
         },
         {
-          "expr": "sum((avg(irate(node_cpu{nodename=~\"$node\", mode=\"user\"}[5m])) * 100))",
+          "expr": "sum((avg(irate(node_cpu_seconds_total{instance=~\"$node\", mode=\"user\"}[5m])) * 100))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "user",
           "refId": "B"
         },
         {
-          "expr": "sum((avg(irate(node_cpu{nodename=~\"$node\", mode=\"iowait\"}[5m])) * 100))",
+          "expr": "sum((avg(irate(node_cpu_seconds_total{instance=~\"$node\", mode=\"iowait\"}[5m])) * 100))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "iowait",
           "refId": "C"
         },
         {
-          "expr": "sum((avg(irate(node_cpu{nodename=~\"$node\", mode=\"steal\"}[5m])) * 100))",
+          "expr": "sum((avg(irate(node_cpu_seconds_total{instance=~\"$node\", mode=\"steal\"}[5m])) * 100))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "steal",
@@ -256,7 +256,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(node_memory_MemAvailable{nodename=~\"$node\"})",
+          "expr": "sum(node_memory_MemAvailable_bytes{instance=~\"$node\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -264,14 +264,14 @@
           "refId": "A"
         },
         {
-          "expr": "sum(node_memory_MemFree{nodename=~\"$node\"})",
+          "expr": "sum(node_memory_MemFree_bytes{instance=~\"$node\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "free",
           "refId": "B"
         },
         {
-          "expr": "sum(node_memory_Active{nodename=~\"$node\"})",
+          "expr": "sum(node_memory_Active_bytes{instance=~\"$node\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "active",
@@ -376,7 +376,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "avg(node_load1{nodename=~\"$node\"})",
+          "expr": "avg(node_load1{instance=~\"$node\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A",
@@ -437,18 +437,18 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(node_filesystem_free_bytes{instance=~\"$node\"}) by (nodename)",
+          "expr": "sum(node_filesystem_free_bytes{instance=~\"$node\"}) by (instance)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{ nodename }} free",
+          "legendFormat": "{{ instance }} free",
           "refId": "B"
         },
         {
-          "expr": "(sum(node_filesystem_size{nodename=~\"$node\"}) by (nodename) - sum(node_filesystem_free) by (nodename))",
+          "expr": "(sum(node_filesystem_size_bytes{instance=~\"$node\"}) by (instance) - sum(node_filesystem_free_bytes) by (instance))",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
-          "legendFormat": "{{ nodename }} usage",
+          "legendFormat": "{{ instance }} usage",
           "refId": "A"
         }
       ],
@@ -530,14 +530,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(node_disk_bytes_read{nodename=~\"$node\"}[5m]))",
+          "expr": "sum(rate(node_disk_read_bytes_total{instance=~\"$node\"}[5m]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Read",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(node_disk_bytes_written{nodename=~\"$node\"}[5m]))",
+          "expr": "sum(rate(node_disk_written_bytes_total{instance=~\"$node\"}[5m]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Write",
@@ -620,14 +620,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(node_disk_reads_completed{nodename=~\"$node\"}[5m]))",
+          "expr": "sum(rate(node_disk_reads_completed_total{instance=~\"$node\"}[5m]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Reads",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(node_disk_writes_completed{nodename=~\"$node\"}[5m]))",
+          "expr": "sum(rate(node_disk_writes_completed_total{instance=~\"$node\"}[5m]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Writes",
@@ -715,14 +715,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(node_network_receive_bytes{nodename=~\"$node\"}[5m]))",
+          "expr": "sum(rate(node_network_receive_bytes_total{instance=~\"$node\"}[5m]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "receive",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(node_network_transmit_bytes{nodename=~\"$node\"}[5m]))",
+          "expr": "sum(rate(node_network_transmit_bytes_total{instance=~\"$node\"}[5m]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "transmit",
@@ -810,14 +810,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(node_network_receive_errs{nodename=~\"$node\"})",
+          "expr": "sum(node_network_receive_errs_total{instance=~\"$node\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "in",
           "refId": "A"
         },
         {
-          "expr": "sum(node_network_transmit_errs{nodename=~\"$node\"})",
+          "expr": "sum(node_network_transmit_errs_total{instance=~\"$node\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "in",
@@ -905,14 +905,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(node_network_receive_packets{nodename=~\"$node\"}[5m]))",
+          "expr": "sum(rate(node_network_receive_packets_total{instance=~\"$node\"}[5m]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "receive",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(node_network_transmit_packets{nodename=~\"$node\"}[5m]))",
+          "expr": "sum(rate(node_network_transmit_packets_total{instance=~\"$node\"}[5m]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "transmit",

--- a/dist/datasource/datasource.js
+++ b/dist/datasource/datasource.js
@@ -74,7 +74,7 @@ System.register(['lodash'], function(exports_1) {
                     });
                 };
                 K8sDatasource.prototype.getDaemonSets = function (namespace) {
-                    return this._get('/apis/extensions/v1beta1/' + addNamespace(namespace) + 'daemonsets')
+                    return this._get('/apis/apps/v1/' + addNamespace(namespace) + 'daemonsets')
                         .then(function (result) {
                         return result.items;
                     });
@@ -86,7 +86,7 @@ System.register(['lodash'], function(exports_1) {
                     });
                 };
                 K8sDatasource.prototype.getDeployments = function (namespace) {
-                    return this._get('/apis/extensions/v1beta1/' + addNamespace(namespace) + 'deployments')
+                    return this._get('/apis/apps/v1/' + addNamespace(namespace) + 'deployments')
                         .then(function (result) {
                         return result.items;
                     });

--- a/dist/datasource/datasource.ts
+++ b/dist/datasource/datasource.ts
@@ -70,7 +70,7 @@ export class K8sDatasource {
   }
 
   getDaemonSets(namespace) {
-    return this._get('/apis/extensions/v1beta1/' + addNamespace(namespace) + 'daemonsets')
+    return this._get('/apis/apps/v1/' + addNamespace(namespace) + 'daemonsets')
       .then(result => {
         return result.items;
       });
@@ -84,7 +84,7 @@ export class K8sDatasource {
   }
 
   getDeployments(namespace) {
-    return this._get('/apis/extensions/v1beta1/' + addNamespace(namespace) + 'deployments')
+    return this._get('/apis/apps/v1/' + addNamespace(namespace) + 'deployments')
       .then(result => {
         return result.items;
       });

--- a/src/components/clusters/clusterConfig.ts
+++ b/src/components/clusters/clusterConfig.ts
@@ -205,7 +205,7 @@ export class ClusterConfigCtrl {
   getDeployments() {
     var self = this;
     return this.backendSrv.request({
-      url: 'api/datasources/proxy/' + self.cluster.id + '/apis/apps/v1beta1/namespaces/kube-system/deployments',
+      url: 'api/datasources/proxy/' + self.cluster.id + '/apis/apps/v1/namespaces/kube-system/deployments',
       method: 'GET',
       headers: {
         'Content-Type': 'application/json'
@@ -308,14 +308,14 @@ export class ClusterConfigCtrl {
 
   checkApiVersion(clusterId) {
     return this.backendSrv.request({
-      url: 'api/datasources/proxy/' + clusterId + '/apis/extensions/v1beta1',
+      url: 'api/datasources/proxy/' + clusterId + '/apis/apps/v1',
       method: 'GET',
       headers: {
         'Content-Type': 'application/json'
       }
     }).then(result => {
       if (!result.resources || result.resources.length === 0) {
-        throw "This Kubernetes cluster does not support v1beta1 of the API which is needed to deploy automatically. " +
+        throw "This Kubernetes cluster does not support v1 of the API which is needed to deploy automatically. " +
           "You can install manually using the instructions at the bottom of the page.";
       }
     });
@@ -334,7 +334,7 @@ export class ClusterConfigCtrl {
 
   createDaemonSet(clusterId, daemonSet) {
     return this.backendSrv.request({
-      url: 'api/datasources/proxy/' + clusterId + '/apis/extensions/v1beta1/namespaces/kube-system/daemonsets',
+      url: 'api/datasources/proxy/' + clusterId + '/apis/apps/v1/namespaces/kube-system/daemonsets',
       method: 'POST',
       data: daemonSet,
       headers: {
@@ -345,14 +345,14 @@ export class ClusterConfigCtrl {
 
   deleteDaemonSet(clusterId) {
     return this.backendSrv.request({
-      url: 'api/datasources/proxy/' + clusterId + '/apis/extensions/v1beta1/namespaces/kube-system/daemonsets/node-exporter',
+      url: 'api/datasources/proxy/' + clusterId + '/apis/apps/v1/namespaces/kube-system/daemonsets/node-exporter',
       method: 'DELETE',
     });
   }
 
   createDeployment(clusterId, deployment) {
     return this.backendSrv.request({
-      url: 'api/datasources/proxy/' + clusterId + '/apis/apps/v1beta1/namespaces/kube-system/deployments',
+      url: 'api/datasources/proxy/' + clusterId + '/apis/apps/v1/namespaces/kube-system/deployments',
       method: 'POST',
       data: deployment,
       headers: {
@@ -363,12 +363,12 @@ export class ClusterConfigCtrl {
 
   deleteDeployment(clusterId, deploymentName) {
     return this.backendSrv.request({
-      url: 'api/datasources/proxy/' + clusterId + '/apis/apps/v1beta1/namespaces/kube-system/deployments/' + deploymentName,
+      url: 'api/datasources/proxy/' + clusterId + '/apis/apps/v1/namespaces/kube-system/deployments/' + deploymentName,
       method: 'DELETE'
     }).then(() => {
       return this.backendSrv.request({
         url: 'api/datasources/proxy/' + clusterId +
-          '/apis/extensions/v1beta1/namespaces/kube-system/replicasets?labelSelector=grafanak8sapp%3Dtrue',
+          '/apis/apps/v1/namespaces/kube-system/replicasets?labelSelector=grafanak8sapp%3Dtrue',
         method: 'DELETE'
       });
     });

--- a/src/components/clusters/partials/clusters.html
+++ b/src/components/clusters/partials/clusters.html
@@ -14,7 +14,7 @@
 	<div ng-if="ctrl.clusters.length === 0">
 		<div style="text-align: center; padding-top: 90px; min-height: 220px; min-width: 400px;  margin: 0 auto;">
 			<i ng-class="icon" class="icon-gf icon-gf-endpoint no-endpoints"></i>
-			<p ng-if="ctrl.isOrgEditor">Looks like you don’t have any clulsters yet.<br>
+			<p ng-if="ctrl.isOrgEditor">Looks like you don’t have any clusters yet.<br>
 				<a class="highlight-word" href="plugins/grafana-kubernetes-app/page/cluster-config">Add a new cluster</a>
 			</p>
 			<p ng-if="!ctrl.isOrgEditor">Your org does not have any clusters configured. Contact your org admin.

--- a/src/dashboards/k8s-cluster.json
+++ b/src/dashboards/k8s-cluster.json
@@ -5,7 +5,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "5.0.0-pre1"
+      "version": "5.0.4"
     },
     {
       "type": "datasource",
@@ -354,7 +354,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "(sum (node_filesystem_size{nodename=~\"$node\"}) - sum (node_filesystem_free{nodename=~\"$node\"})) / sum (node_filesystem_size{nodename=~\"$node\"})",
+          "expr": "(sum (node_filesystem_size_bytes{instance=~\"$node\"}) - sum (node_filesystem_free_bytes{instance=~\"$node\"})) / sum (node_filesystem_size_bytes{instance=~\"$node\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
@@ -693,14 +693,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(node_filesystem_size{nodename=~\"$node\"}) - sum(node_filesystem_free{nodename=~\"$node\"})",
+          "expr": "sum(node_filesystem_size_bytes{instance=~\"$node\"}) - sum(node_filesystem_free_bytes{instance=~\"$node\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "usage",
           "refId": "A"
         },
         {
-          "expr": "sum(node_filesystem_size{nodename=~\"$node\"})",
+          "expr": "sum(node_filesystem_size_bytes{instance=~\"$node\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "limit",

--- a/src/dashboards/k8s-cluster.json
+++ b/src/dashboards/k8s-cluster.json
@@ -8,19 +8,31 @@
       "version": "5.0.4"
     },
     {
-      "type": "datasource",
-      "id": "prometheus",
-      "name": "Prometheus",
-      "version": "1.0.0"
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": "5.0.0"
     },
     {
       "type": "panel",
       "id": "singlestat",
       "name": "Singlestat",
-      "version": ""
+      "version": "5.0.0"
     }
   ],
-  "annotations": {},
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
   "description": "Summary metrics about containers running on Kubernetes nodes.",
   "editable": true,
   "gnetId": null,
@@ -65,7 +77,7 @@
       "datasource": "$datasource",
       "format": "percentunit",
       "gauge": {
-        "maxValue": 1,
+        "maxValue": 100,
         "minValue": 0,
         "show": true,
         "thresholdLabels": false,
@@ -120,7 +132,7 @@
           "refId": "A"
         }
       ],
-      "thresholds": ".8,.9",
+      "thresholds": "80,90",
       "title": "Cluster Pod Usage",
       "type": "singlestat",
       "valueFontSize": "80%",
@@ -145,7 +157,7 @@
       "datasource": "$datasource",
       "format": "percentunit",
       "gauge": {
-        "maxValue": 1,
+        "maxValue": 100,
         "minValue": 0,
         "show": true,
         "thresholdLabels": false,
@@ -200,7 +212,7 @@
           "refId": "A"
         }
       ],
-      "thresholds": ".8,.9",
+      "thresholds": "80,90",
       "title": "Cluster CPU Usage",
       "type": "singlestat",
       "valueFontSize": "80%",
@@ -225,7 +237,7 @@
       "datasource": "$datasource",
       "format": "percentunit",
       "gauge": {
-        "maxValue": 1,
+        "maxValue": 100,
         "minValue": 0,
         "show": true,
         "thresholdLabels": false,
@@ -280,7 +292,7 @@
           "refId": "A"
         }
       ],
-      "thresholds": ".8,.9",
+      "thresholds": "80,90",
       "title": "Cluster Memory Usage",
       "type": "singlestat",
       "valueFontSize": "80%",
@@ -305,7 +317,7 @@
       "datasource": "$datasource",
       "format": "percentunit",
       "gauge": {
-        "maxValue": 1,
+        "maxValue": 100,
         "minValue": 0,
         "show": true,
         "thresholdLabels": false,
@@ -360,7 +372,7 @@
           "refId": "A"
         }
       ],
-      "thresholds": ".8,.9",
+      "thresholds": "80,90",
       "title": "Cluster Disk Usage",
       "type": "singlestat",
       "valueFontSize": "80%",
@@ -2065,7 +2077,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(delta(kube_pod_container_status_restarts{namespace=\"kube-system\"}[30m]))",
+          "expr": "sum(delta(kube_pod_container_status_restarts_total{namespace=~\"$namespace\"}[30m]))",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"

--- a/src/dashboards/k8s-container.json
+++ b/src/dashboards/k8s-container.json
@@ -126,10 +126,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(container_memory_usage_bytes{pod_name=~\"$pod\"}) by (pod_name)",
+          "expr": "sum(container_memory_usage_bytes{pod=~\"$pod\"}) by (pod)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{ pod_name }}",
+          "legendFormat": "{{ pod }}",
           "refId": "A"
         }
       ],
@@ -217,10 +217,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(irate(container_cpu_usage_seconds_total{pod_name=~\"$pod\"}[2m])) by (pod_name)",
+          "expr": "sum(irate(container_cpu_usage_seconds_total{pod=~\"$pod\"}[2m])) by (pod)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{ pod_name }}",
+          "legendFormat": "{{ pod }}",
           "refId": "A"
         }
       ],
@@ -307,11 +307,11 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(container_network_transmit_bytes_total{pod_name=~\"$pod\", kubernetes_io_hostname=~\"$node\"}[2m])",
+          "expr": "rate(container_network_transmit_bytes_total{pod=~\"$pod\", kubernetes_io_hostname=~\"$node\"}[2m])",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "{{ pod_name }}",
+          "legendFormat": "{{ pod }}",
           "refId": "A"
         }
       ],
@@ -398,10 +398,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(container_network_receive_bytes_total{pod_name=~\"$pod\", kubernetes_io_hostname=~\"$node\"}[2m])",
+          "expr": "rate(container_network_receive_bytes_total{pod=~\"$pod\", kubernetes_io_hostname=~\"$node\"}[2m])",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{ pod_name }}",
+          "legendFormat": "{{ pod }}",
           "refId": "A"
         }
       ],
@@ -489,10 +489,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(container_fs_io_time_seconds_total{pod_name=~\"$pod\"}[2m])",
+          "expr": "rate(container_fs_io_time_seconds_total{pod=~\"$pod\"}[2m])",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{pod_name}}",
+          "legendFormat": "{{ pod }}",
           "refId": "A"
         }
       ],
@@ -577,10 +577,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(container_fs_write_seconds_total{pod_name=~\"$pod\"}[2m])",
+          "expr": "rate(container_fs_write_seconds_total{pod=~\"$pod\"}[2m])",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{ pod_name }}",
+          "legendFormat": "{{ pod }}",
           "refId": "A"
         }
       ],

--- a/src/dashboards/k8s-container.json
+++ b/src/dashboards/k8s-container.json
@@ -5,7 +5,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "5.0.0-pre1"
+      "version": "5.0.4"
     },
     {
       "type": "panel",

--- a/src/dashboards/k8s-deployments.json
+++ b/src/dashboards/k8s-deployments.json
@@ -5,7 +5,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "5.0.0-pre1"
+      "version": "5.0.4"
     },
     {
       "type": "panel",

--- a/src/dashboards/k8s-node.json
+++ b/src/dashboards/k8s-node.json
@@ -5,7 +5,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "5.0.0-pre1"
+      "version": "5.0.4"
     },
     {
       "type": "panel",
@@ -437,7 +437,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(node_filesystem_free{nodename=~\"$node\"}) by (nodename)",
+          "expr": "sum(node_filesystem_free_bytes{instance=~\"$node\"}) by (nodename)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{ nodename }} free",

--- a/src/dashboards/k8s-node.json
+++ b/src/dashboards/k8s-node.json
@@ -143,7 +143,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum((avg(irate(node_cpu{nodename=~\"$node\", mode=\"system\"}[5m])) * 100))",
+          "expr": "sum((avg(irate(node_cpu_seconds_total{instance=~\"$node\", mode=\"system\"}[5m])) * 100))",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -152,21 +152,21 @@
           "refId": "A"
         },
         {
-          "expr": "sum((avg(irate(node_cpu{nodename=~\"$node\", mode=\"user\"}[5m])) * 100))",
+          "expr": "sum((avg(irate(node_cpu_seconds_total{instance=~\"$node\", mode=\"user\"}[5m])) * 100))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "user",
           "refId": "B"
         },
         {
-          "expr": "sum((avg(irate(node_cpu{nodename=~\"$node\", mode=\"iowait\"}[5m])) * 100))",
+          "expr": "sum((avg(irate(node_cpu_seconds_total{instance=~\"$node\", mode=\"iowait\"}[5m])) * 100))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "iowait",
           "refId": "C"
         },
         {
-          "expr": "sum((avg(irate(node_cpu{nodename=~\"$node\", mode=\"steal\"}[5m])) * 100))",
+          "expr": "sum((avg(irate(node_cpu_seconds_total{instance=~\"$node\", mode=\"steal\"}[5m])) * 100))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "steal",
@@ -256,7 +256,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(node_memory_MemAvailable{nodename=~\"$node\"})",
+          "expr": "sum(node_memory_MemAvailable_bytes{instance=~\"$node\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -264,14 +264,14 @@
           "refId": "A"
         },
         {
-          "expr": "sum(node_memory_MemFree{nodename=~\"$node\"})",
+          "expr": "sum(node_memory_MemFree_bytes{instance=~\"$node\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "free",
           "refId": "B"
         },
         {
-          "expr": "sum(node_memory_Active{nodename=~\"$node\"})",
+          "expr": "sum(node_memory_Active_bytes{instance=~\"$node\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "active",
@@ -376,7 +376,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "avg(node_load1{nodename=~\"$node\"})",
+          "expr": "avg(node_load1{instance=~\"$node\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A",
@@ -437,18 +437,18 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(node_filesystem_free_bytes{instance=~\"$node\"}) by (nodename)",
+          "expr": "sum(node_filesystem_free_bytes{instance=~\"$node\"}) by (instance)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{ nodename }} free",
+          "legendFormat": "{{ instance }} free",
           "refId": "B"
         },
         {
-          "expr": "(sum(node_filesystem_size{nodename=~\"$node\"}) by (nodename) - sum(node_filesystem_free) by (nodename))",
+          "expr": "(sum(node_filesystem_size_bytes{instance=~\"$node\"}) by (instance) - sum(node_filesystem_free_bytes) by (instance))",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
-          "legendFormat": "{{ nodename }} usage",
+          "legendFormat": "{{ instance }} usage",
           "refId": "A"
         }
       ],
@@ -530,14 +530,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(node_disk_bytes_read{nodename=~\"$node\"}[5m]))",
+          "expr": "sum(rate(node_disk_read_bytes_total{instance=~\"$node\"}[5m]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Read",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(node_disk_bytes_written{nodename=~\"$node\"}[5m]))",
+          "expr": "sum(rate(node_disk_written_bytes_total{instance=~\"$node\"}[5m]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Write",
@@ -620,14 +620,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(node_disk_reads_completed{nodename=~\"$node\"}[5m]))",
+          "expr": "sum(rate(node_disk_reads_completed_total{instance=~\"$node\"}[5m]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Reads",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(node_disk_writes_completed{nodename=~\"$node\"}[5m]))",
+          "expr": "sum(rate(node_disk_writes_completed_total{instance=~\"$node\"}[5m]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Writes",
@@ -715,14 +715,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(node_network_receive_bytes{nodename=~\"$node\"}[5m]))",
+          "expr": "sum(rate(node_network_receive_bytes_total{instance=~\"$node\"}[5m]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "receive",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(node_network_transmit_bytes{nodename=~\"$node\"}[5m]))",
+          "expr": "sum(rate(node_network_transmit_bytes_total{instance=~\"$node\"}[5m]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "transmit",
@@ -810,14 +810,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(node_network_receive_errs{nodename=~\"$node\"})",
+          "expr": "sum(node_network_receive_errs_total{instance=~\"$node\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "in",
           "refId": "A"
         },
         {
-          "expr": "sum(node_network_transmit_errs{nodename=~\"$node\"})",
+          "expr": "sum(node_network_transmit_errs_total{instance=~\"$node\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "in",
@@ -905,14 +905,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(node_network_receive_packets{nodename=~\"$node\"}[5m]))",
+          "expr": "sum(rate(node_network_receive_packets_total{instance=~\"$node\"}[5m]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "receive",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(node_network_transmit_packets{nodename=~\"$node\"}[5m]))",
+          "expr": "sum(rate(node_network_transmit_packets_total{instance=~\"$node\"}[5m]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "transmit",

--- a/src/datasource/datasource.ts
+++ b/src/datasource/datasource.ts
@@ -70,7 +70,7 @@ export class K8sDatasource {
   }
 
   getDaemonSets(namespace) {
-    return this._get('/apis/extensions/v1beta1/' + addNamespace(namespace) + 'daemonsets')
+    return this._get('/apis/apps/v1/' + addNamespace(namespace) + 'daemonsets')
       .then(result => {
         return result.items;
       });
@@ -84,7 +84,7 @@ export class K8sDatasource {
   }
 
   getDeployments(namespace) {
-    return this._get('/apis/extensions/v1beta1/' + addNamespace(namespace) + 'deployments')
+    return this._get('/apis/apps/v1/' + addNamespace(namespace) + 'deployments')
       .then(result => {
         return result.items;
       });


### PR DESCRIPTION
### This pull request fully works with the following versions:

`current - October-10-2019`

Kubernetes: **v1.16.1** `[current v1.16.1]`

Node exporter: **v0.18.1** `[current v0.18.1]`

Kube-state-metrics: **v1.8.0** `[current v1.8.0]`

Prometheus: **v2.13.0** `[current v2.13.0]`

Grafana: **v5.0.0-5.0.4** `[current v6.4.2] *explained below`


### About the exporters:

The deploy button present in the plugin have the most updated version of the file. However you may need to re-check, since updates or permissions may have changed. 

**For a fully working solution you can use the code from the repository as stated below.**

You can check this repository (under development) that contains the full stack where this pull request was tested, in order to fully work with the plugin and all the recent versions - https://github.com/andre-lx/grafana-prometheus-exporters


### About prometheus config file:

The only thing that changed in the config file, is the replacement of the value present in the "instance" key in some metrics from the ip from the node, to the node name.

```
.
.
.
- source_labels: ['__meta_kubernetes_pod_node_name']
        action: replace
        target_label: instance
.
.
.
```

### About grafana version:

**!!! Javascript developer wanted !!!**

The plugin works in the most recent versions, but the custom pannels created for version 5.0.0 starts to fail in some functionalities for versions 5.0.4+. 

Aready debugged: 

| Versions    | Comment                                                          |   
|-------------|------------------------------------------------------------------|
| 5.0.0-5.0.4 | everithing ok - FULLY COMPATIBLE                                 |  
| 5.1.0-5.3.4 | lost scrool on node custom panel after select node               | 
| 5.4.0-5.4.5 | URL is updated but not the charts on container dashboard         |  
| 6.0.0+      | after this version - lost scroll, URL update and charts updates  | 

### API Versions updates:

| API         | Current version                                                 | Pull request version                                 |
|-------------|-----------------------------------------------------------------|------------------------------------------------------|
| API K8S     | /apis/apps/v1beta1/namespaces/                                  |  /apis/apps/v1/namespaces/                           |
| API K8S     | /apis/extensions/v1beta1/namespaces/                            | /apis/apps/v1/namespaces/                            |
| API K8S     | /apis/extensions/v1beta1/' + addNamespace(namespace)            | /apis/apps/v1/' + addNamespace(namespace)            |
| API K8S     | /apis/extensions/v1beta1/                                       | /apis/apps/v1                                        |
| API K8S     | api/datasources/proxy/' + clusterId + '/apis/extensions/v1beta1 | api/datasources/proxy/' + clusterId + '/apis/apps/v1 |
| Deployment  | apps/v1beta1                                                    | apps/v1                                              |
| DaemonSet   | extensions/v1beta1                                              | apps/v1                                              |

### Component versions updates:

| Component           | Current version  | Pull request version |
|---------------------|------------------|----------------------|
| Kubernetes          | v1.6+            | v1.16.1              |
| Node exporter       | v0.15.0          | v0.18.1              |
| Kube state metrics  | v1.1.0           | v1.8.0               |
| Prometheus          | ???              | v2.13.0              |
| Grafana             | v5.0.0           | v5.0.4               |

### If you want to use this fork of the project:

1. If you don't have the plugin already installed, please install using the grafana cli ``grafana-cli plugins install grafana-kubernetes-app``

2. If you already have the plugin installed:
2.1 Go to your grafana plugins folder
2.2 Move/delete the plugin folder ``mv grafana-kubernetes-app grafana-kubernetes-app.old``
2.3 ``git clone https://github.com/andre-lx/kubernetes-app.git grafana-kubernetes-app``
2.4 Restart grafana service
2.5 Go to your plugin config page inside grafana -> Dashboards -> Re-import the four dashboards
